### PR TITLE
Fixing a markdown error

### DIFF
--- a/index.md
+++ b/index.md
@@ -65,11 +65,11 @@ Member of the Milan (Italy) Bar. Inactive.
 
 [Blog & other links](http://vrnc.info/)
 
-## [Jason Boehmig] (https://github.com/jboehmig)
+## [Jason Boehmig](https://github.com/jboehmig)
 
 Member of the California Bar.
 
-[Firm Website] (http://www.fenwick.com/professionals/Pages/jasonboehmig.aspx)
+[Firm Website](http://www.fenwick.com/professionals/Pages/jasonboehmig.aspx)
 
 ## Law Students
 


### PR DESCRIPTION
Although Github's markdown parser overlooked these spaces between "]" and "(", the markdown parser used to generate the webpage was not as forgiving.
