### PR TITLE
Remove extraneous control character

### DIFF
--- a/index.md
+++ b/index.md
@@ -155,7 +155,7 @@ Member of the New York and Massachusetts Bar
 [Firm Website](http://curtis.com/sitecontent.cfm?pageid=8&itemid=353)
 
 ## [Kyle Mitchell](https://github.com/kemitchell)
-
+
 Member of the California Bar.
 
 [@kemitchell](https://twitter.com/kemitchell)


### PR DESCRIPTION
For some reason an extraneous "^A" character, which renders are garbage in HTML, appears just before my listing. This pull request removes it.